### PR TITLE
RFC: Backport progressbar fix

### DIFF
--- a/onfire/colab/runners.py
+++ b/onfire/colab/runners.py
@@ -127,7 +127,7 @@ class TrainTracker:
             metrics.append(self.valid_loss[-1])
             metrics.extend([metric.value for metric in self.metrics])
         res = default_metrics + metrics
-        return [x if isinstance(x, int) else round(x, decimals) for x in res]
+        return [str(x) if isinstance(x, int) else str(round(x, decimals)) for x in res]
 
     def _process_valid_output(self, valid_output):
         res = defaultdict(list)


### PR DESCRIPTION
This PR brings the fix in 0.1.4 to the partial_fit branch (based on 0.1.3) that we are currently using for pads.

Related commit:
https://github.com/joshfp/pytorch-onfire/commit/9817c5e5624f783f4040d9a9748fbba1a1df6a3e