### PR TITLE
RFC: Feature/log clip negative

### DIFF
--- a/onfire/colab/runners.py
+++ b/onfire/colab/runners.py
@@ -127,7 +127,7 @@ class TrainTracker:
             metrics.append(self.valid_loss[-1])
             metrics.extend([metric.value for metric in self.metrics])
         res = default_metrics + metrics
-        return [x if isinstance(x, int) else round(x, decimals) for x in res]
+        return [str(x) if isinstance(x, int) else str(round(x, decimals)) for x in res]
 
     def _process_valid_output(self, valid_output):
         res = defaultdict(list)

--- a/onfire/fields.py
+++ b/onfire/fields.py
@@ -146,18 +146,19 @@ class TextFeature(BaseFeature):
 
 
 class ContinuousFeature(BaseFeature):
-    def __init__(self, key=None, preprocessor=None, imputer=None, scaler=None, log=False, log_auto_scale=True):
+    def __init__(self, key=None, preprocessor=None, imputer=None, scaler=None, log=False, log_auto_scale=True, log_clip_values=False):
         self.key = key
         self.preprocessor = preprocessor
         self.imputer = (imputer or SimpleImputer()) if imputer!=False else None
         self.scaler = (scaler or StandardScaler()) if scaler!=False else None
         self.log = log
         self.log_auto_scale = log_auto_scale
+        self.log_clip_values = log_clip_values
 
         tfms = []
         tfms.append(To2DFloatArray())
         if self.imputer: tfms.append(self.imputer)
-        if self.log: tfms.append(Log(auto_scale=self.log_auto_scale))
+        if self.log: tfms.append(Log(auto_scale=self.log_auto_scale, clip_values=self.log_clip_values))
         if self.scaler: tfms.append(self.scaler)
         super().__init__(self.key, self.preprocessor, tfms, dtype=torch.float32)
 
@@ -258,15 +259,16 @@ class MultiLabelTarget(BaseField):
 
 
 class ContinuousTarget(BaseField):
-    def __init__(self, key=None, preprocessor=None, log=False, log_auto_scale=False):
+    def __init__(self, key=None, preprocessor=None, log=False, log_auto_scale=False, log_clip_values=False):
         self.key = key
         self.preprocessor = preprocessor
         self.log = log
         self.log_auto_scale = log_auto_scale
+        self.log_clip_values = log_clip_values
 
         tfms = []
         tfms.append(To2DFloatArray())
-        if self.log: tfms.append(Log(auto_scale=self.log_auto_scale))
+        if self.log: tfms.append(Log(auto_scale=self.log_auto_scale, clip_values=self.log_clip_values))
 
         super().__init__(self.key, self.preprocessor, tfms, dtype=torch.float32)
 

--- a/onfire/transformers.py
+++ b/onfire/transformers.py
@@ -226,7 +226,7 @@ class Log(PartialFitBase, TransformerMixin):
     def transform(self, X):
         X = X + self.offset
         if self.clip_values:
-            X = np.clip(X, np.finfo(np.float32).eps)
+            X = np.clip(X, np.finfo(np.float32).eps, None)
         return np.log(X)
 
     @property

--- a/onfire/transformers.py
+++ b/onfire/transformers.py
@@ -210,9 +210,9 @@ class To2DFloatArray(PartialFitBase, TransformerMixin):
 
 
 class Log(PartialFitBase, TransformerMixin):
-    def __init__(self, auto_scale, log_clip_values=False):
+    def __init__(self, auto_scale, clip_values=False):
         self.auto_scale = auto_scale
-        self.log_clip_values = log_clip_values
+        self.clip_values = clip_values
         super().__init__()
 
     def _reset(self, X):
@@ -225,7 +225,7 @@ class Log(PartialFitBase, TransformerMixin):
 
     def transform(self, X):
         X = X + self.offset
-        if self.log_clip_values:
+        if self.clip_values:
             X = np.clip(X, np.finfo(np.float32).eps)
         return np.log(X)
 

--- a/onfire/transformers.py
+++ b/onfire/transformers.py
@@ -210,8 +210,9 @@ class To2DFloatArray(PartialFitBase, TransformerMixin):
 
 
 class Log(PartialFitBase, TransformerMixin):
-    def __init__(self, auto_scale):
+    def __init__(self, auto_scale, log_clip_values=False):
         self.auto_scale = auto_scale
+        self.log_clip_values = log_clip_values
         super().__init__()
 
     def _reset(self, X):
@@ -223,7 +224,10 @@ class Log(PartialFitBase, TransformerMixin):
         return self
 
     def transform(self, X):
-        return np.log(X + self.offset)
+        X = X + self.offset
+        if self.log_clip_values:
+            X = np.clip(X, np.finfo(np.float32).eps)
+        return np.log(X)
 
     @property
     def offset(self):


### PR DESCRIPTION
Adds option to clip zero/negative values that cloud we passed to `Log`. The feature is disable by default so that it's backward compatible.

Includes change from https://github.com/joshfp/pytorch-onfire/pull/3