### PR TITLE
map size config + ProjectorFeature

### DIFF
--- a/onfire/data.py
+++ b/onfire/data.py
@@ -14,10 +14,11 @@ __all__ = [
 
 class OnFireDataLoader(DataLoader):
     def __init__(self, data, tfms, batch_size, shuffle=False, num_workers=0,
-                 sampler=None, pin_memory=None, drop_last=False, **kwargs):
+                 sampler=None, pin_memory=None, drop_last=False, map_size:int=1024**4,
+                 **kwargs):
         num_workers = num_workers if num_workers else os.cpu_count()
         pin_memory = pin_memory if pin_memory != None else torch.cuda.is_available()
-        self.ds = OnFireDataset(data, max_readers=num_workers)
+        self.ds = OnFireDataset(data, max_readers=num_workers, map_size = map_size)
         self.tfms = tfms if isinstance(tfms, (list, tuple)) else [tfms]
         super().__init__(self.ds, batch_size=batch_size, shuffle=shuffle,
                          num_workers=num_workers, collate_fn=self.__collate, sampler=sampler,
@@ -28,11 +29,11 @@ class OnFireDataLoader(DataLoader):
 
 
 class OnFireDataset(Dataset):
-    def __init__(self, data, max_readers):
+    def __init__(self, data, max_readers, map_size:int=1024**4):
         self.use_lmdb = max_readers > 1
         if self.use_lmdb:
             tmpdir = tempfile.TemporaryDirectory().name
-            self.db = lmdb.open(tmpdir, map_size=1024**4, lock=False, max_readers=max_readers)
+            self.db = lmdb.open(tmpdir, map_size=map_size, lock=False, max_readers=max_readers)
             self.key_struct = struct.Struct("!q")
             it = [(self.key_struct.pack(i), msgpack.packb(x)) for i, x in enumerate(data)]
             with self.db.begin(write=True) as txn:

--- a/onfire/fields.py
+++ b/onfire/fields.py
@@ -255,3 +255,31 @@ class ContinuousTarget(BaseField):
     @property
     def output_dim(self):
         return self.out_dim
+
+class ProyectorFeature():
+    def __init__(self, processor:BaseFeature, key:str):
+        self.projector = Projector(keys=key)
+        self.processor = processor
+
+    def fit(self, X, y=None):
+        self.processor.fit(self.projector.transform(X))
+        return self.processor
+
+    def transform(self, X):
+        projected = self.projector.transform(X)
+        return self.processor.transform(projected)
+
+    def inverse_transform(self, X):
+        unprojected = self.inverse_transform(X)
+        return self.projector.inverse_transform(unprojected)
+
+    def build_embedder(self):
+        return self.processor.build_embedder()
+
+    @property
+    def output_dim(self):
+        self.processor.embedder.output_dim
+
+    @property
+    def embedder(self):
+        return self.processor.embedder


### PR DESCRIPTION
This PR add the map_size as a parameter of the OnFireDataLoader & OnFireDataset init methods. This allows some training in machines that doesn't have enough available memory. I used it for some discovery trainings with less data.

Also, this PR added another kind of Feature. The ProjectorFeature. It is to allow the same embedder and the same pipeline for different fields. For example, I am building a classifier to choose an item from 4 candidates. I need to describe them in the same way. The data could come with each row in this format:

> {'feature_1': '10214',
>   'item_0': {'categorical_feature_1': 'PCE',
>    'text_feature_1': 'Here, I have text',
>    'categorical_feature_2': 'PGC',
>    'categorical_feature_3': 'False',
>    'numerical_feature_1': 1.0},
>   'target': '2',
>   'item_2':{'categorical_feature_1': 'UE',
>    'text_feature_1': 'Here, I have text and more text',
>    'categorical_feature_2': 'PNB',
>    'categorical_feature_3': 'False',
>    'numerical_feature_1': 8.0},
>   'item_4':{'categorical_feature_1': 'PCE',
>    'text_feature_1': 'Here, I have text and more more more text',
>    'categorical_feature_2': 'PGT',
>    'categorical_feature_3': 'True',
>    'numerical_feature_1': 3.2},
>   'item_1': {'categorical_feature_1': 'PCE',
>    'text_feature_1': 'Here, I have much text',
>    'categorical_feature_2': 'PGC',
>    'categorical_feature_3': 'False',
>    'numerical_feature_1': 1.0},
>   'item_3': {'categorical_feature_1': 'PCE',
>    'text_feature_1': 'Here, I have much much text',
>    'categorical_feature_2': 'PGC',
>    'categorical_feature_3': 'False',
>    'numerical_feature_1': 1.0}

The way to use it is

1. Define an item descriptor as a FeatureGroup for each item. It will be the same for each one.

<pre><code>def get_item_descriptor():

    return FeatureGroup([
        ('categorical_feature_1', CategoricalFeature('categorical_feature_1')),
        ('text_feature_1', TextFeature('text_feature_1', max_len=15,max_vocab=5000,min_freq=10, emb_dim=30)),
        ('numerical_feature_1', ContinuousFeature('numerical_feature_1', log=True, scaler=None)),
        ('categorical_feature_2', CategoricalFeature('categorical_feature_2')),
        ('categorical_feature_3', CategoricalFeature('categorical_feature_3'))
    ])</code></pre>

2. Define a descriptor for the features of the row, in this case we only have one feature:

`def get_feature_descriptor():
    return CategoricalFeature('feature_1')`

3. Define the target descriptor:

`def get_target_descriptor():
    return SingleLabelTarget('target', dtype=torch.long)`
    
4. Define the projector:

`def get_projector(processor:BaseFeature, key:str):
    return ProyectorFeature(processor, key)`

5. Then the descriptors are fitted in this way in an Estimator class:

<pre><code>class NextItemEstimator:
    def __init__(self, ps):
        self.ps = ps
    
    def fit_descriptors(self, data):
        self.feature_descriptor = get_feature_descriptor().fit(data)
        self.item_descriptor = get_item_descriptor()
        self.item_descriptor = get_projector(self.item_descriptor,'0').fit(data)
        self.target_descriptor = get_target_descriptor().fit(data)
        
        self.item0_descriptor = get_projector(self.item_descriptor, '0')
        self.item1_descriptor = get_projector(self.item_descriptor, '1')
        self.item2_descriptor = get_projector(self.item_descriptor, '2')
        self.item3_descriptor = get_projector(self.item_descriptor, '3')
        self.item4_descriptor = get_projector(self.item_descriptor, '4')

    def fit(self, train_data, valid_data, batch_size, epochs, lr, neg_sampling_factor, num_workers=None):
        # fit descriptors
        self.fit_descriptors(train_data)
       # set the tranformers
        tfms = (
            self.feature_descriptor.transform,
            self.item0_descriptor.transform,
            self.item1_descriptor.transform,
            self.item2_descriptor.transform,
            self.item3_descriptor.transform,
            self.item4_descriptor.transform,
            self.target_descriptor.transform,
        )
        # DataLoaders
        train_dl = OnFireDataLoader(train_data, tfms, batch_size=batch_size, num_workers=num_workers, shuffle=True)
        valid_dl = OnFireDataLoader(valid_data, tfms, batch_size=batch_size, num_workers=num_workers)</code></pre>